### PR TITLE
parse: split ESMTP parameters on the first '=' only

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -52,15 +52,10 @@ func parseCmd(line string) (cmd string, arg string, err error) {
 func parseArgs(s string) (map[string]string, error) {
 	argMap := map[string]string{}
 	for _, arg := range strings.Fields(s) {
-		m := strings.Split(arg, "=")
-		switch len(m) {
-		case 2:
-			argMap[strings.ToUpper(m[0])] = m[1]
-		case 1:
-			argMap[strings.ToUpper(m[0])] = ""
-		default:
-			return nil, fmt.Errorf("failed to parse arg string: %q", arg)
-		}
+		// Split on the first '=' only: parameter values may themselves
+		// contain '=' (e.g. AUTH=dXNlcg== with base64 padding, RFC 4954).
+		key, value, _ := strings.Cut(arg, "=")
+		argMap[strings.ToUpper(key)] = value
 	}
 	return argMap, nil
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -42,3 +42,36 @@ func TestParser(t *testing.T) {
 		}
 	}
 }
+
+func TestParseArgs(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want map[string]string
+	}{
+		{" BODY=8BITMIME SIZE=1024 SMTPUTF8", map[string]string{
+			"BODY": "8BITMIME", "SIZE": "1024", "SMTPUTF8": "",
+		}},
+		// Values may contain '=', e.g. base64 padding in AUTH (RFC 4954)
+		// or xtext-free ORCPT values; only the first '=' separates the key.
+		{" AUTH=dXNlcg==", map[string]string{"AUTH": "dXNlcg=="}},
+		{" ORCPT=rfc822;user=x@example.org", map[string]string{
+			"ORCPT": "rfc822;user=x@example.org",
+		}},
+	}
+	for _, tc := range tests {
+		got, err := parseArgs(tc.raw)
+		if err != nil {
+			t.Errorf("parseArgs(%q) = %v", tc.raw, err)
+			continue
+		}
+		if len(got) != len(tc.want) {
+			t.Errorf("parseArgs(%q) = %v, want %v", tc.raw, got, tc.want)
+			continue
+		}
+		for k, v := range tc.want {
+			if got[k] != v {
+				t.Errorf("parseArgs(%q)[%q] = %q, want %q", tc.raw, k, got[k], v)
+			}
+		}
+	}
+}


### PR DESCRIPTION
parseArgs rejected any MAIL/RCPT parameter whose value itself contains '=', e.g. AUTH=dXNlcg== (base64 padding, RFC 4954) or ORCPT values. The server turned this into a permanent 501, bouncing mail from otherwise working clients.

Use strings.Cut so only the first '=' separates key from value.