### PR TITLE
server: harden the STARTTLS handshake

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -929,15 +929,55 @@ func (c *Conn) handleStartTLS() {
 
 	c.writeResponse(220, EnhancedCode{2, 0, 0}, "Ready to start TLS")
 
+	// Defense against the STARTTLS plaintext command injection attack: any
+	// bytes buffered past the STARTTLS line were received before the TLS
+	// handshake and must never be interpreted as if they had arrived inside
+	// the encrypted channel. Their presence indicates an injection attempt, so
+	// abort the connection rather than silently discarding them.
+	if n := c.text.R.Buffered(); n > 0 {
+		c.server.ErrorLog.Printf("starttls: %d buffered bytes before TLS handshake, possible plaintext command injection", n)
+		c.Close()
+		// Closing the socket is not enough: the buffered plaintext still lives
+		// in c.text's reader and the serve loop would otherwise read and
+		// dispatch it as commands. Rebuild the reader over the now-closed
+		// connection so the buffered bytes are discarded and the next read
+		// fails, ending the serve loop.
+		c.init()
+		return
+	}
+
+	// Apply fresh deadlines for the handshake so a client that stalls
+	// mid-handshake cannot pin this goroutine indefinitely. This mirrors the
+	// implicit-TLS path in Server.handleConn; without it the STARTTLS handshake
+	// would run under whatever stale deadline the previous read/write left, or
+	// none at all when timeouts are disabled.
+	if d := c.server.ReadTimeout; d != 0 {
+		c.conn.SetReadDeadline(time.Now().Add(d))
+	}
+	if d := c.server.WriteTimeout; d != 0 {
+		c.conn.SetWriteDeadline(time.Now().Add(d))
+	}
+
 	// Upgrade to TLS
 	tlsConn := tls.Server(c.conn, c.server.TLSConfig)
 
 	if err := tlsConn.Handshake(); err != nil {
-		c.writeResponse(550, EnhancedCode{5, 0, 0}, "Handshake error")
+		c.server.ErrorLog.Printf("starttls: handshake failed: %v", err)
+		// The TLS layer has already consumed bytes from the connection and the
+		// peer expects TLS records, so the plaintext stream is desynchronized.
+		// Close rather than attempting to continue or to write a plaintext
+		// response the peer cannot interpret.
+		c.Close()
 		return
 	}
 
+	// Guard the connection swap with c.locker: Conn.Close() reads c.conn under
+	// the same lock and can run on a different goroutine during
+	// Server.Close/Shutdown. Without this, the unsynchronized write to c.conn
+	// races that locked read (a torn read of the interface value could crash).
+	c.locker.Lock()
 	c.conn = tlsConn
+	c.locker.Unlock()
 	c.init()
 
 	// Reset all state and close the previous Session.

--- a/server_test.go
+++ b/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -1285,6 +1286,78 @@ func TestServer_TooLongCommand(t *testing.T) {
 	scanner.Scan()
 	if !strings.HasPrefix(scanner.Text(), "500 5.4.0 ") {
 		t.Fatal("Invalid too long MAIL response:", scanner.Text())
+	}
+}
+
+// readUntilClosed drains c until EOF/reset and returns everything read.
+// It fails the test if the read blocks until the deadline instead of the
+// server closing the connection.
+func readUntilClosed(t *testing.T, c net.Conn) []byte {
+	t.Helper()
+	c.SetReadDeadline(time.Now().Add(5 * time.Second))
+	data, err := io.ReadAll(c)
+	if err != nil {
+		var ne net.Error
+		if errors.As(err, &ne) && ne.Timeout() {
+			t.Fatal("Connection was not closed by the server")
+		}
+		// Other errors (e.g. connection reset) also mean the server
+		// dropped the connection, which is what we expect.
+	}
+	return data
+}
+
+func TestStartTLS_handshakeFailureClosesConnection(t *testing.T) {
+	_, s, c, scanner, caps := testServerEhlo(t, func(s *smtp.Server) {
+		s.TLSConfig = &tls.Config{}
+	})
+	defer s.Close()
+	defer c.Close()
+
+	if _, ok := caps["STARTTLS"]; !ok {
+		t.Fatal("STARTTLS capability is missing")
+	}
+
+	io.WriteString(c, "STARTTLS\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "220 ") {
+		t.Fatal("Invalid STARTTLS response:", scanner.Text())
+	}
+
+	// Not a TLS ClientHello: the handshake fails and the plaintext stream is
+	// desynchronized, so the server must close the connection instead of
+	// writing a plaintext response into it.
+	io.WriteString(c, "this is not a TLS handshake\r\n")
+
+	data := readUntilClosed(t, c)
+	if strings.Contains(string(data), "550 ") {
+		t.Fatal("Server wrote a plaintext response into a desynchronized stream:", string(data))
+	}
+}
+
+func TestStartTLS_rejectsPipelinedCommands(t *testing.T) {
+	_, s, c, scanner, caps := testServerEhlo(t, func(s *smtp.Server) {
+		s.TLSConfig = &tls.Config{}
+	})
+	defer s.Close()
+	defer c.Close()
+
+	if _, ok := caps["STARTTLS"]; !ok {
+		t.Fatal("STARTTLS capability is missing")
+	}
+
+	// Plaintext command injection (CVE-2011-0411 pattern): commands pipelined
+	// after STARTTLS were received outside TLS and must not be executed as if
+	// they had arrived inside the encrypted channel.
+	io.WriteString(c, "STARTTLS\r\nNOOP\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "220 ") {
+		t.Fatal("Invalid STARTTLS response:", scanner.Text())
+	}
+
+	data := readUntilClosed(t, c)
+	if strings.Contains(string(data), "250 ") {
+		t.Fatal("Server executed a command injected before the TLS handshake:", string(data))
 	}
 }
 


### PR DESCRIPTION
Three related fixes to handleStartTLS:

- Abort the connection if bytes are buffered past the STARTTLS line. Such bytes were received in plaintext and must never be dispatched as commands after the handshake (plaintext command injection, CVE-2011-0411 pattern).

- Apply fresh Read/WriteTimeout deadlines around the handshake, mirroring the implicit-TLS path. Previously a client stalling mid-handshake could pin the goroutine and its connection slot indefinitely.

- Close the connection when the handshake fails instead of writing a plaintext 550 into a desynchronized stream and continuing, and guard the c.conn swap with c.locker since Conn.Close reads it under the same lock from other goroutines during Server.Close/Shutdown.