### PR TITLE
server: create a new session on re-EHLO

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -233,17 +233,28 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 	if c.session != nil {
 		// RFC 5321: "... the SMTP server MUST clear all buffers
 		// and reset the state exactly as if a RSET command has been issued."
-		c.reset()
-	} else {
-		sess, err := c.server.Backend.NewSession(c)
-		if err != nil {
-			c.helo = ""
-			c.writeError(451, EnhancedCode{4, 0, 0}, err)
-			return
-		}
 
-		c.setSession(sess)
+		// Tear the session down entirely instead of only resetting it, so the
+		// backend re-evaluates the connection in NewSession below. Backends
+		// use NewSession for per-connection policy (reverse DNS, DNSBL,
+		// reputation); a long-lived connection that re-issues EHLO must not
+		// keep a session created before those signals changed.
+		if err := c.session.Logout(); err != nil {
+			c.server.ErrorLog.Printf("Failed to logout session on re-EHLO: %v", err)
+		}
+		c.setSession(nil)
+		c.reset()
 	}
+
+	// Create a new session, whether this is the first EHLO or a re-EHLO.
+	sess, err := c.server.Backend.NewSession(c)
+	if err != nil {
+		c.helo = ""
+		c.writeError(451, EnhancedCode{4, 0, 0}, err)
+		return
+	}
+
+	c.setSession(sess)
 
 	if !enhanced {
 		c.writeResponse(250, EnhancedCode{2, 0, 0}, fmt.Sprintf("Hello %s", domain))

--- a/server_test.go
+++ b/server_test.go
@@ -30,6 +30,9 @@ type message struct {
 type backend struct {
 	authDisabled bool
 
+	// Number of times NewSession was called.
+	sessions int
+
 	messages []*message
 	anonmsgs []*message
 
@@ -54,6 +57,7 @@ type backend struct {
 }
 
 func (be *backend) NewSession(_ *smtp.Conn) (smtp.Session, error) {
+	be.sessions++
 	if be.implementLMTPData {
 		return &lmtpSession{&session{backend: be, anonymous: true}}, nil
 	}
@@ -352,6 +356,32 @@ func TestServer_helo(t *testing.T) {
 	scanner.Scan()
 	if !strings.HasPrefix(scanner.Text(), "250 ") {
 		t.Fatal("Invalid HELO response:", scanner.Text())
+	}
+}
+
+func TestServer_reEhloCreatesNewSession(t *testing.T) {
+	be, s, c, scanner, _ := testServerEhlo(t)
+	defer s.Close()
+	defer c.Close()
+
+	if be.sessions != 1 {
+		t.Fatal("Invalid number of sessions after first EHLO:", be.sessions)
+	}
+
+	// RFC 5321 allows EHLO later in the session; the backend must get a fresh
+	// session so it can re-evaluate per-connection policy in NewSession.
+	io.WriteString(c, "EHLO localhost\r\n")
+	for scanner.Scan() {
+		if strings.HasPrefix(scanner.Text(), "250 ") {
+			break
+		}
+		if !strings.HasPrefix(scanner.Text(), "250-") {
+			t.Fatal("Invalid EHLO response:", scanner.Text())
+		}
+	}
+
+	if be.sessions != 2 {
+		t.Fatal("Invalid number of sessions after re-EHLO:", be.sessions)
 	}
 }
 


### PR DESCRIPTION
RFC 5321 permits EHLO at any point in the session. Previously a repeated EHLO only reset the existing session, so the backend never saw the boundary. Backends use NewSession for per-connection policy (reverse DNS, DNSBL, reputation scoring); a long-lived connection that re-issues EHLO between messages could keep delivering on a session created before those signals changed.

Log out the old session and ask the backend for a fresh one on every EHLO/HELO, matching what STARTTLS already does after the handshake.