### PR TITLE
feat: EHLO client-compatibility options and RFC 5321 first-line domain

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -393,7 +393,9 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 	c.setSession(sess)
 
 	if !enhanced {
-		c.writeResponse(250, EnhancedCode{2, 0, 0}, fmt.Sprintf("Hello %s", domain))
+		// RFC 5321 §4.1.1.1: the first element of a HELO reply is the
+		// server's domain, not free text.
+		c.writeResponse(250, EnhancedCode{2, 0, 0}, c.helloReplyLine(domain))
 		return
 	}
 
@@ -416,6 +418,11 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 
 		if len(mechs) > 0 {
 			caps = append(caps, authCap)
+			if c.server.EnableLegacyAuthCap {
+				// Obsolete "AUTH=" form for Microsoft clients; see
+				// Server.EnableLegacyAuthCap.
+				caps = append(caps, "AUTH="+strings.Join(mechs, " "))
+			}
 		}
 	}
 	if c.server.EnableSMTPUTF8 {
@@ -435,7 +442,7 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 	} else {
 		caps = append(caps, "SIZE")
 	}
-	if c.server.MaxRecipients > 0 {
+	if c.server.MaxRecipients > 0 && !c.server.DisableLimitsCap {
 		caps = append(caps, fmt.Sprintf("LIMITS RCPTMAX=%v", c.server.MaxRecipients))
 	}
 	if c.server.EnableRRVS {
@@ -459,9 +466,22 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 		caps = append(caps, "XCLIENT ADDR PORT PROTO HELO LOGIN NAME")
 	}
 
-	args := []string{"Hello " + domain}
+	// RFC 5321 §4.1.1.1: the first line of an EHLO reply carries the
+	// server's domain; the client greeting is trailing text.
+	args := []string{c.helloReplyLine(domain)}
 	args = append(args, caps...)
 	c.writeResponse(250, NoEnhancedCode, args...)
+}
+
+// helloReplyLine builds the first line of a HELO/EHLO reply. Per RFC 5321
+// §4.1.1.1 it must start with the server's domain; the greeting for the
+// client is appended as free text. When Server.Domain is unset, fall back to
+// the historical "Hello <client>" form.
+func (c *Conn) helloReplyLine(clientDomain string) string {
+	if c.server.Domain != "" {
+		return fmt.Sprintf("%s Hello %s", c.server.Domain, clientDomain)
+	}
+	return fmt.Sprintf("Hello %s", clientDomain)
 }
 
 // READY state -> waiting for MAIL

--- a/ehlo_caps_test.go
+++ b/ehlo_caps_test.go
@@ -1,0 +1,177 @@
+package smtp_test
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-smtp"
+)
+
+// sendEhloReadCaps sends EHLO and returns the first reply line (without the
+// "250-" prefix) and the set of capability lines.
+func sendEhloReadCaps(t *testing.T, c io.Writer, scanner *bufio.Scanner) (first string, caps []string) {
+	t.Helper()
+
+	io.WriteString(c, "EHLO client.example.org\r\n")
+
+	scanner.Scan()
+	line := scanner.Text()
+	if !strings.HasPrefix(line, "250-") && !strings.HasPrefix(line, "250 ") {
+		t.Fatal("Invalid EHLO response:", line)
+	}
+	first = line[4:]
+	if strings.HasPrefix(line, "250 ") {
+		return first, nil // single-line reply, no capabilities
+	}
+
+	for scanner.Scan() {
+		s := scanner.Text()
+		if strings.HasPrefix(s, "250 ") {
+			caps = append(caps, strings.TrimPrefix(s, "250 "))
+			return first, caps
+		}
+		if !strings.HasPrefix(s, "250-") {
+			t.Fatal("Invalid capability response:", s)
+		}
+		caps = append(caps, strings.TrimPrefix(s, "250-"))
+	}
+	t.Fatal("EHLO reply ended without a terminating 250 line")
+	return "", nil
+}
+
+func hasCap(caps []string, want string) bool {
+	for _, c := range caps {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+// RFC 5321 §4.1.1.1: the first line of an EHLO reply must carry the server's
+// domain, not free text. The classic Outlook lineage reads this line.
+func TestEhloFirstLineCarriesServerDomain(t *testing.T) {
+	_, s, c, scanner := testServerGreeted(t)
+	defer s.Close()
+	defer c.Close()
+
+	first, _ := sendEhloReadCaps(t, c, scanner)
+	if first != "localhost Hello client.example.org" {
+		t.Fatal("EHLO first line must start with the server domain, got:", first)
+	}
+}
+
+// When Server.Domain is unset the historical "Hello <client>" form is kept.
+func TestEhloFirstLineNoDomainFallback(t *testing.T) {
+	_, s, c, scanner := testServer(t, func(s *smtp.Server) {
+		s.Domain = ""
+	})
+	defer s.Close()
+	defer c.Close()
+
+	scanner.Scan() // greeting (domain-less)
+
+	first, _ := sendEhloReadCaps(t, c, scanner)
+	if first != "Hello client.example.org" {
+		t.Fatal("Expected fallback greeting without domain, got:", first)
+	}
+}
+
+// HELO replies must also lead with the server domain.
+func TestHeloReplyCarriesServerDomain(t *testing.T) {
+	_, s, c, scanner := testServerGreeted(t)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "HELO client.example.org\r\n")
+	scanner.Scan()
+	if scanner.Text() != "250 2.0.0 localhost Hello client.example.org" {
+		t.Fatal("HELO reply must start with the server domain, got:", scanner.Text())
+	}
+}
+
+// EnableLegacyAuthCap adds the obsolete "AUTH=<mechs>" line that Microsoft
+// clients (Outlook) look for — the same workaround as Postfix's
+// broken_sasl_auth_clients. It must mirror the standard AUTH line exactly.
+func TestLegacyAuthCapEnabled(t *testing.T) {
+	_, s, c, scanner := testServerGreeted(t, func(s *smtp.Server) {
+		s.EnableLegacyAuthCap = true
+	})
+	defer s.Close()
+	defer c.Close()
+
+	_, caps := sendEhloReadCaps(t, c, scanner)
+	if !hasCap(caps, "AUTH PLAIN") {
+		t.Fatal("Missing standard AUTH capability, got:", caps)
+	}
+	if !hasCap(caps, "AUTH=PLAIN") {
+		t.Fatal("Missing legacy AUTH= capability, got:", caps)
+	}
+}
+
+// Off by default: no legacy line unless explicitly enabled.
+func TestLegacyAuthCapDisabledByDefault(t *testing.T) {
+	_, s, c, scanner := testServerGreeted(t)
+	defer s.Close()
+	defer c.Close()
+
+	_, caps := sendEhloReadCaps(t, c, scanner)
+	if !hasCap(caps, "AUTH PLAIN") {
+		t.Fatal("Missing standard AUTH capability, got:", caps)
+	}
+	for _, cap := range caps {
+		if strings.HasPrefix(cap, "AUTH=") {
+			t.Fatal("Legacy AUTH= capability advertised without EnableLegacyAuthCap:", cap)
+		}
+	}
+}
+
+// No AUTH advertised at all -> no legacy line either, even when enabled.
+func TestLegacyAuthCapNoMechanisms(t *testing.T) {
+	be, s, c, scanner := testServerGreeted(t, func(s *smtp.Server) {
+		s.EnableLegacyAuthCap = true
+	})
+	defer s.Close()
+	defer c.Close()
+	be.authDisabled = true
+
+	_, caps := sendEhloReadCaps(t, c, scanner)
+	for _, cap := range caps {
+		if strings.HasPrefix(cap, "AUTH") {
+			t.Fatal("AUTH capability advertised with auth disabled:", cap)
+		}
+	}
+}
+
+// LIMITS (RFC 9422) is advertised when MaxRecipients is set...
+func TestLimitsCapDefault(t *testing.T) {
+	_, s, c, scanner := testServerGreeted(t, func(s *smtp.Server) {
+		s.MaxRecipients = 100
+	})
+	defer s.Close()
+	defer c.Close()
+
+	_, caps := sendEhloReadCaps(t, c, scanner)
+	if !hasCap(caps, "LIMITS RCPTMAX=100") {
+		t.Fatal("Missing LIMITS capability, got:", caps)
+	}
+}
+
+// ...and suppressed by DisableLimitsCap for clients whose parsers choke on it.
+func TestLimitsCapDisabled(t *testing.T) {
+	_, s, c, scanner := testServerGreeted(t, func(s *smtp.Server) {
+		s.MaxRecipients = 100
+		s.DisableLimitsCap = true
+	})
+	defer s.Close()
+	defer c.Close()
+
+	_, caps := sendEhloReadCaps(t, c, scanner)
+	for _, cap := range caps {
+		if strings.HasPrefix(cap, "LIMITS") {
+			t.Fatal("LIMITS capability advertised despite DisableLimitsCap:", cap)
+		}
+	}
+}

--- a/lmtp_server_test.go
+++ b/lmtp_server_test.go
@@ -40,7 +40,7 @@ func sendDeliveryCmdsLMTP(t *testing.T, scanner *bufio.Scanner, c io.Writer) {
 func sendLHLO(t *testing.T, scanner *bufio.Scanner, c io.Writer) {
 	io.WriteString(c, "LHLO localhost\r\n")
 	scanner.Scan()
-	if scanner.Text() != "250-Hello localhost" {
+	if scanner.Text() != "250-localhost Hello localhost" {
 		t.Fatal("Invalid LHLO response:", scanner.Text())
 	}
 	for scanner.Scan() {

--- a/server.go
+++ b/server.go
@@ -68,6 +68,20 @@ type Server struct {
 	// timer race each other and can send the client a duplicate notice.
 	OnTimeout func()
 
+	// Advertise the obsolete "AUTH=<mechanisms>" EHLO line in addition to the
+	// standard "AUTH <mechanisms>" capability. Several Microsoft client
+	// lineages (Outlook and its cloud sync fleet) look for the legacy "AUTH="
+	// form and refuse to attempt authentication when it is absent; Postfix
+	// ships the identical workaround as broken_sasl_auth_clients. Conforming
+	// clients ignore unknown EHLO keywords, so enabling this is harmless for
+	// everyone else.
+	EnableLegacyAuthCap bool
+
+	// Suppress the "LIMITS RCPTMAX=..." (RFC 9422) capability that is
+	// otherwise advertised when MaxRecipients > 0. The extension is recent
+	// and rarely deployed; some client capability parsers mishandle it.
+	DisableLimitsCap bool
+
 	// Advertise SMTPUTF8 (RFC 6531) capability.
 	// Should be used only if backend supports it.
 	EnableSMTPUTF8 bool

--- a/server_test.go
+++ b/server_test.go
@@ -304,7 +304,7 @@ func testServerEhlo(t *testing.T, fn ...serverConfigureFunc) (be *backend, s *sm
 	io.WriteString(c, "EHLO localhost\r\n")
 
 	scanner.Scan()
-	if scanner.Text() != "250-Hello localhost" {
+	if scanner.Text() != "250-localhost Hello localhost" {
 		t.Fatal("Invalid EHLO response:", scanner.Text())
 	}
 


### PR DESCRIPTION
Three changes to the HELO/EHLO reply surface, motivated by Microsoft Outlook's sync fleet closing submission connections ~50ms after the TLS handshake without ever attempting AUTH (August 2026 incident — worked against Postfix, failed against this server):

- Server.EnableLegacyAuthCap advertises the obsolete "AUTH=<mechanisms>" EHLO line in addition to the standard "AUTH <mechanisms>" capability. Microsoft client lineages look for the legacy "AUTH=" form and refuse to authenticate when it is absent; Postfix ships the identical workaround as broken_sasl_auth_clients. Off by default.

- Server.DisableLimitsCap suppresses the "LIMITS RCPTMAX=..." (RFC 9422) capability otherwise advertised when MaxRecipients > 0. The extension is young and can confuse client capability parsers. Off by default (LIMITS still advertised).

- HELO and EHLO replies now lead with the server's domain per RFC 5321 §4.1.1.1 ("250-<domain> Hello <client>") when Server.Domain is set, falling back to the historical "Hello <client>" form when it is not.