### PR TITLE
parse: add unit test for ESMTP parameter splitting

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -177,3 +177,36 @@ func TestParseCmd(t *testing.T) {
 		})
 	}
 }
+
+func TestParseArgs(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want map[string]string
+	}{
+		{" BODY=8BITMIME SIZE=1024 SMTPUTF8", map[string]string{
+			"BODY": "8BITMIME", "SIZE": "1024", "SMTPUTF8": "",
+		}},
+		// Values may contain '=', e.g. base64 padding in AUTH (RFC 4954)
+		// or xtext-free ORCPT values; only the first '=' separates the key.
+		{" AUTH=dXNlcg==", map[string]string{"AUTH": "dXNlcg=="}},
+		{" ORCPT=rfc822;user=x@example.org", map[string]string{
+			"ORCPT": "rfc822;user=x@example.org",
+		}},
+	}
+	for _, tc := range tests {
+		got, err := parseArgs(tc.raw)
+		if err != nil {
+			t.Errorf("parseArgs(%q) = %v", tc.raw, err)
+			continue
+		}
+		if len(got) != len(tc.want) {
+			t.Errorf("parseArgs(%q) = %v, want %v", tc.raw, got, tc.want)
+			continue
+		}
+		for k, v := range tc.want {
+			if got[k] != v {
+				t.Errorf("parseArgs(%q)[%q] = %q, want %q", tc.raw, k, got[k], v)
+			}
+		}
+	}
+}


### PR DESCRIPTION
`parseArgs` splits ESMTP parameters on the first `=` only (`strings.Cut`), but has no direct test coverage on `sora` — `parse_test.go` only covers `parseReversePath` and `parseCmd`, and `rcpt_extensions_test.go` notes the gap explicitly:

> Mock the parseArgs function behavior (this would need to be extracted to test properly)

This adds `TestParseArgs` covering the cases that motivated the first-`=` split:

- `AUTH=dXNlcg==` — base64 padding (RFC 4954)
- `ORCPT=rfc822;user=x@example.org` — `=` inside the value
- plus the ordinary `BODY=8BITMIME SIZE=1024 SMTPUTF8` case, including the valueless parameter

Verified the test is a real regression guard: reverting `parseArgs` to the previous `strings.Split` implementation makes it fail with `failed to parse arg string` on both `AUTH` and `ORCPT`, which is what turned legitimate mail into a permanent 501.

Test only — no production code changes. Full suite passes, including under `-race`.

The test is extracted from #11; that PR targets `master`, where the `parse.go` fix is still needed. `sora` already has the fix, so only the test is carried over here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)