### PR TITLE
parse: document why ESMTP parameters split on the first '=' only

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -54,6 +54,9 @@ func parseCmd(line string) (cmd string, arg string, err error) {
 func parseArgs(s string) (map[string]string, error) {
 	argMap := map[string]string{}
 	for _, arg := range strings.Fields(s) {
+		// Split on the first '=' only: parameter values may themselves
+		// contain '=' (e.g. AUTH=dXNlcg== with base64 padding, RFC 4954,
+		// or an ORCPT address).
 		key, value, found := strings.Cut(arg, "=")
 		if found {
 			argMap[strings.ToUpper(key)] = value


### PR DESCRIPTION
Follow-up to #15, which landed the `TestParseArgs` coverage. This carries over the one remaining piece of #11: the comment explaining *why* `parseArgs` splits on the first `=` only.

No behaviour change — comment only.

The constraint isn't obvious from `strings.Cut` alone, and getting it wrong is expensive: the previous `strings.Split` implementation returned `failed to parse arg string` for `AUTH=dXNlcg==` (base64 padding, RFC 4954) and for `ORCPT` values containing `=`, which the server turned into a permanent 501 — bouncing mail from otherwise working clients.

Full suite passes; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)